### PR TITLE
Added bitdock to Homebrew Cask + update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ The app sits in the top-menu and shows the value of the selected crypto in eithe
 
 Built with [Electron](http://electron.atom.io), uses the [CryptoCompare API](https://www.cryptocompare.com/api).
 
+
+## Installing via Homebrew Cask
+```sh
+brew cask install bitdock
+```
+
 ## Running
 
 ```sh


### PR DESCRIPTION
after I [added bitdock to Homebrew Cask](https://github.com/caskroom/homebrew-cask/pull/41779), It's time to update the README so people would know they can download it with Cask tool